### PR TITLE
Adds some config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ Sharing of passwords, keys, and files can be difficult to perform securely. This
 Configuration options are stored in config/initializers/snapsecret.rb, and can be used to:
 
 - Restrict creation of secrets to email addresses from certain domains.
-- Allow various oauth providers to authenticate when creating a secret
+- Restrict sharing of secrets to email addresses from certain domains.
+- Set a maximum expiry time for secrets.
 
 The typical workflow is:
 

--- a/app/models/auth_token.rb
+++ b/app/models/auth_token.rb
@@ -1,5 +1,7 @@
 class AuthToken < ActiveRecord::Base
   validates :email, email: true
+  validate :email_domain_authorised
+
   def generate
     update_attributes(hashed_token: SecureRandom.hex, expire_at: Time.now + 7.days)
     self
@@ -8,4 +10,14 @@ class AuthToken < ActiveRecord::Base
   def notify(request_host)
     AuthTokenMailer.auth_token(email, hashed_token, request_host).deliver_now
   end
+
+  def email_domain_authorised
+    authorised_domains = Rails.application.config.snapsecret_domains_allowed_to_create_secrets
+    email_domain = email.to_s.split('@')[1]
+    if authorised_domains && email_domain && [authorised_domains].flatten.exclude?(email_domain)
+      errors.add(:email, "Email addresses @#{email_domain} are not authorised to create secrets")
+    end
+    true
+  end
+
 end

--- a/app/views/secrets/new.html.erb
+++ b/app/views/secrets/new.html.erb
@@ -13,7 +13,7 @@
       </div>
       <div class='form-group'>
         <%= f.input :comments, input_html: { class: 'form-control' } %>
-        <%= f.input :expire_at, as: :string, input_html: { class: 'datepicker form-control' } %>
+        <%= f.input :expire_at, as: :string, input_html: { class: 'datepicker form-control' }, hint: Secret.expire_at_hint %>
       </div>
       <%= f.submit 'Create', class: 'btn btn-primary' %>
     <% end %>

--- a/config/initializers/snapsecret.rb
+++ b/config/initializers/snapsecret.rb
@@ -1,0 +1,20 @@
+# If you want to limit the amount of time a secret can be stored, set the time
+# limit here. e.g. if you set 7.days, any secrets older than 7 days cannot be
+# accessed and will be deleted.
+# Set to nil or comment the line if you don't want to enforce this restriction
+Rails.configuration.snapsecret_maximum_expiry_time = 7.days.to_i
+
+# Only allow secrets to be created by email addresses from certain domains.
+# e.g. if you set to 'acme.com', only email addresses @acme.com will be able to
+# create secrets, anyone else who requests an auth token will receive an error.
+# Takes a single string: 'acme.com' or an array: ['acme.com', 'acme.org']
+# Set to nil or comment the line if you don't want to enforce this restriction
+Rails.configuration.snapsecret_domains_allowed_to_create_secrets = nil
+
+# Only allow secrets to be shared with email addresses from certain domains.
+# e.g. if you set to 'acme.com', only email addresses @acme.com will be able to
+# receive secrets, setting the 'To address' setting to another domain will
+# receive an error when creating a secret.
+# Takes a single string: 'acme.com' or an array: ['acme.com', 'acme.org']
+# Set to nil or comment the line if you don't want to enforce this restriction
+Rails.configuration.snapsecret_domains_allowed_to_receive_secrets = nil

--- a/spec/models/auth_token_spec.rb
+++ b/spec/models/auth_token_spec.rb
@@ -2,6 +2,10 @@ require 'rails_helper'
 
 describe AuthToken do
 
+  before do
+    allow(Rails.configuration).to receive(:snapsecret_domains_allowed_to_create_secrets) { nil }
+  end
+
   describe '#generate' do
 
     let!(:auth_token) { AuthToken.new(email: 'a@a.com') }
@@ -33,6 +37,39 @@ describe AuthToken do
       expect(email.to).to eq(['b@b.com'])
       expect(email.body.to_s).to match(/https:\/\/example.com\/auth_tokens\/\S+/)
     end
+  end
+
+  describe '#email_domain_authorised' do
+
+    let(:auth_token) { AuthToken.new(email: 'c@c.com') }
+
+    it 'allows auth tokens to be created when the config setting is nil' do
+      allow(Rails.configuration).to receive(:snapsecret_domains_allowed_to_create_secrets) { nil }
+      expect(auth_token).to be_valid
+    end
+
+    it 'allows auth tokens to be created when the email domain matches the config setting' do
+      allow(Rails.configuration).to receive(:snapsecret_domains_allowed_to_create_secrets) { 'c.com' }
+      expect(auth_token).to be_valid
+    end
+
+    it 'allows auth tokens to be created when the email domain is one of those provided in the config setting' do
+      allow(Rails.configuration).to receive(:snapsecret_domains_allowed_to_create_secrets) { ['b.com', 'c.com'] }
+      expect(auth_token).to be_valid
+    end
+
+    it 'does not allow auth tokens to be created when the email domain does not match the config setting' do
+      allow(Rails.configuration).to receive(:snapsecret_domains_allowed_to_create_secrets) { 'd.com' }
+      expect(auth_token).to_not be_valid
+      expect(auth_token.errors[:email]).to eq(['Email addresses @c.com are not authorised to create secrets'])
+    end
+
+    it 'does not allow auth tokens to be created when the email domain is not one of those provided in the config setting' do
+      allow(Rails.configuration).to receive(:snapsecret_domains_allowed_to_create_secrets) { ['d.com', 'e.com'] }
+      expect(auth_token).to_not be_valid
+      expect(auth_token.errors[:email]).to eq(['Email addresses @c.com are not authorised to create secrets'])
+    end
+
   end
 
 end

--- a/spec/services/secret_service_spec.rb
+++ b/spec/services/secret_service_spec.rb
@@ -21,7 +21,10 @@ describe SecretService do
 
   describe '#decrypt_secret' do
 
-    let!(:secret) { SecretService.encrypt_secret({secret: 'aBc123', to_email: 'a@a.com', from_email: 'b@b.com'}, 'https://example.com') }
+    let!(:secret) {
+      SecretService.encrypt_secret({secret: 'aBc123', to_email: 'a@a.com', from_email: 'b@b.com', expire_at: Time.now + 7.days},
+        'https://example.com')
+    }
     let!(:retrieved_secret) { Secret.find(secret.id) }
     let(:secret_key) { ActionMailer::Base.deliveries.last.body.to_s.match(/https:\/\/example.com\/[\w-]*\/(\w*)\//)[1] }
 


### PR DESCRIPTION
Adds config options (+ validations/specs) to config/initializers/snapsecret.rb:

snapsecret_maximum_expiry_time
snapsecret_domains_allowed_to_create_secrets
snapsecret_domains_allowed_to_receive_secrets
