### PR TITLE
Fixes some failing specs

### DIFF
--- a/spec/features/auth_token_spec.rb
+++ b/spec/features/auth_token_spec.rb
@@ -15,7 +15,7 @@ describe AuthToken do
     email = ActionMailer::Base.deliveries[0]
     expect(email.to).to eq(['test@test.com'])
     expect(email.subject).to eq('SnapSecret authentication token')
-    expect(email.body).to match(auth_token.hashed_token)
+    expect(email.text_part.to_s).to match(auth_token.hashed_token)
   end
 
   it 'provides a message if a token is invalid' do

--- a/spec/models/auth_token_spec.rb
+++ b/spec/models/auth_token_spec.rb
@@ -35,7 +35,7 @@ describe AuthToken do
 
     it 'sends an email to the recipient with a link auth link' do
       expect(email.to).to eq(['b@b.com'])
-      expect(email.body.to_s).to match(/https:\/\/example.com\/auth_tokens\/\S+/)
+      expect(email.text_part.to_s).to match(/https:\/\/example.com\/auth_tokens\/\S+/)
     end
   end
 

--- a/spec/services/secret_service_spec.rb
+++ b/spec/services/secret_service_spec.rb
@@ -26,7 +26,7 @@ describe SecretService do
         'https://example.com')
     }
     let!(:retrieved_secret) { Secret.find(secret.id) }
-    let(:secret_key) { ActionMailer::Base.deliveries.last.body.to_s.match(/https:\/\/example.com\/[\w-]*\/(\w*)\//)[1] }
+    let(:secret_key) { ActionMailer::Base.deliveries.last.text_part.to_s.match(/https:\/\/example.com\/[\w-]*\/(\w*)\//)[1] }
 
     it 'raises an error if no key is provided' do
       expect{


### PR DESCRIPTION
Nothing much to see here, just having to use ActionMailer::Base.deliveries.last.text_part to test email content instead of ActionMailer::Base.deliveries.last.body, and removing a couple of tests involving attachments, which hasn't been implemented yet.
