### PR TITLE
asking for recipient email address in auth token form

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ The typlical workflow:
 ---------------------------
 
 - Someone visits [https://topsekr.it/](https://topsekr.it/) and enters their email
-  address.
+  address and the recipient's email address. The recipient's email address isn't strictly necessary at this point but it reduces confusion for non-technical users.
 - An email link with a one-time authentication token is sent to the email.
 - They follow the link to a form where they can enter the secret info that they want
-  to share, including the recipient's email address.
+  to share. The recipient's email address will automatically be filled in if it was provided when creating the auth token.
 - The secret is encrypted with a one time key, the encrypted secret is stored on the
   server without the key.
 - A link to decrypt the secret is sent to the recipient's email address including the

--- a/app/controllers/auth_tokens_controller.rb
+++ b/app/controllers/auth_tokens_controller.rb
@@ -5,7 +5,7 @@ class AuthTokensController < ApplicationController
     if auth_token
       session[:email] = auth_token.email
       auth_token.delete
-      redirect_to new_secret_path
+      redirect_to new_secret_path(recipient_email: auth_token.recipient_email)
     else
       flash[:message] = "Token not found"
       render :new
@@ -30,7 +30,7 @@ class AuthTokensController < ApplicationController
   private
 
   def auth_token_params
-    params.require(:auth_token).permit(:email)
+    params.require(:auth_token).permit(:email, :recipient_email)
   end
 
 end

--- a/app/controllers/secrets_controller.rb
+++ b/app/controllers/secrets_controller.rb
@@ -8,7 +8,7 @@ class SecretsController < ApplicationController
   end
 
   def new
-    @secret = Secret.new
+    @secret = Secret.new(to_email: params[:recipient_email])
   end
 
   def create

--- a/app/views/auth_tokens/new.html.erb
+++ b/app/views/auth_tokens/new.html.erb
@@ -1,7 +1,8 @@
 <div class='row'>
   <div class="col-md-6">
     <%= simple_form_for :auth_token, url: auth_tokens_url, html: { class: 'form-inline' } do |f| %>
-      <%= f.input :email, wrapper_html: { class: 'form-group' }, input_html: { class: 'form-control' } %>
+      <%= f.input :email, label: 'Your Email', wrapper_html: { class: 'form-group' }, input_html: { class: 'form-control' } %>
+      <%= f.input :recipient_email, label: 'Their Email', wrapper_html: { class: 'form-group' }, input_html: { class: 'form-control' } %>
       <div class='form-group'>
         <%= f.submit 'Send', class: 'btn btn-primary' %>
         <%= link_to image_tag('g64.png', alt: 'g+'), '/auth/google_oauth2', id: 'oauth-google' %>

--- a/db/migrate/20150627003713_add_recipient_address_to_auth_tokens.rb
+++ b/db/migrate/20150627003713_add_recipient_address_to_auth_tokens.rb
@@ -1,0 +1,5 @@
+class AddRecipientAddressToAuthTokens < ActiveRecord::Migration
+  def change
+    add_column :auth_tokens, :recipient_email, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150416012902) do
+ActiveRecord::Schema.define(version: 20150627003713) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,15 +20,16 @@ ActiveRecord::Schema.define(version: 20150416012902) do
     t.string   "email"
     t.string   "hashed_token"
     t.datetime "expire_at"
-    t.datetime "created_at",   null: false
-    t.datetime "updated_at",   null: false
+    t.datetime "created_at",      null: false
+    t.datetime "updated_at",      null: false
+    t.string   "recipient_email"
   end
 
   create_table "secrets", force: :cascade do |t|
     t.string   "title"
     t.string   "from_email"
     t.string   "to_email"
-    t.string   "encrypted_secret"
+    t.text     "encrypted_secret"
     t.string   "encrypted_secret_salt"
     t.string   "encrypted_secret_iv"
     t.string   "uuid"


### PR DESCRIPTION
Fixes https://github.com/reinteractive/topsekrit/issues/23
This change adds a recipient email address field to the auth token form. When the auth token is consumed this recipient address is used to fill out the to_email field in the secret form.
While it isn't necessary to ask for the recipient's email address at the time of generating an auth token, this will hopefully reduce confusion for non-techical users who have been entering the recipient's email address instead of theirs in the auth_token.email field.
