### PR TITLE
updated email subject to include the secret id

### DIFF
--- a/app/mailers/secret_mailer.rb
+++ b/app/mailers/secret_mailer.rb
@@ -4,12 +4,12 @@ class SecretMailer < BaseMailer
     @request_host = request_host
     @secret = secret
     @auth_token = AuthToken.create(email: secret.from_email).generate
-    mail(to: secret.to_email, subject: 'A secret has been shared with you via Topsekrit')
+    mail(to: secret.to_email, subject: "Topsekrit ID#{secret.id}: A secret has been shared with you")
   end
 
   def consumnation_notification(secret)
     @secret = secret
-    mail(to: secret.from_email, subject: 'Secret consumed on topsekrit')
+    mail(to: secret.from_email, subject: "Secret ID#{secret.id} consumed on topsekrit")
   end
 
 end

--- a/spec/features/secret_feature_spec.rb
+++ b/spec/features/secret_feature_spec.rb
@@ -36,7 +36,7 @@ describe Secret do
       it 'sends an email to the recipient' do
         email = ActionMailer::Base.deliveries.last
         expect(email.to).to eq(['example@example.com'])
-        expect(email.subject).to eq('A secret has been shared with you via Topsekrit')
+        expect(email.subject).to eq("Topsekrit ID#{Secret.last.id}: A secret has been shared with you")
         expect(email.text_part.to_s).to match("This link will show you the secret:")
         expect(email.text_part.to_s).to match("/#{secret.uuid}/.+/.+")
       end
@@ -91,7 +91,7 @@ describe Secret do
         expect(page).to have_content('cdefg')
         email = ActionMailer::Base.deliveries.last
         expect(email.to).to eq(['a@a.com'])
-        expect(email.subject).to eq('Secret consumed on topsekrit')
+        expect(email.subject).to eq("Secret ID#{Secret.last.id} consumed on topsekrit")
         expect(email.text_part.to_s).to match('b@b.com')
         expect(email.text_part.to_s).to match('The encrypted information has now been deleted from the database')
       end


### PR DESCRIPTION
Fixes https://github.com/reinteractive/topsekrit/issues/21
Makes email subject field unique by adding the secret id to it.
