### PR TITLE
disable multiple form submits

### DIFF
--- a/app/assets/javascripts/topsekrit.js
+++ b/app/assets/javascripts/topsekrit.js
@@ -1,3 +1,6 @@
 $(document).ready(function() {
   $('.datepicker').pickadate();
+  $('form').on('submit', function(e){
+    $(e.target).find('input[type="submit"]').prop('disabled', true);
+  });
 });


### PR DESCRIPTION
Fixes https://github.com/reinteractive/topsekrit/issues/12
Disables multiple form submissions with JS.
For example someone might accidentally click on the submit button twice and create two secrets.
