### PR TITLE
Replace 'reinteractive.net' with 'reinteractive.com'

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 TOPSEKRIT_AUTHORISATION_SETTING='open'
-TOPSEKRIT_AUTHORISED_DOMAIN='reinteractive.net'
+TOPSEKRIT_AUTHORISED_DOMAIN='reinteractive.com'
 GOOGLE_OAUTH_CALLBACK_PATH='/auth/google_oauth2/callback'
 GOOGLE_CLIENT_ID='<client_id>'
 GOOGLE_CLIENT_SECRET='<client_secret>'

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ notifications:
 env:
   global:
     - TOPSEKRIT_AUTHORISATION_SETTING='open'
-    - TOPSEKRIT_AUTHORISED_DOMAIN='reinteractive.net'
+    - TOPSEKRIT_AUTHORISED_DOMAIN='reinteractive.com'
     - GOOGLE_OAUTH_CALLBACK_PATH='/auth/google_oauth2/callback'
     - GOOGLE_CLIENT_ID='1234'
     - GOOGLE_CLIENT_SECRET='1234'

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ application allows a secret to be shared and viewed via a unique url. After the
 secret is viewed once, it is deleted.
 
 TopSekr.it is available for anyone to use at [https://TopSekr.it/](https://TopSekr.it/),
-it is a Ruby on Rails application created and built by [reinteractive](https://reinteractive.net/)
-and hosted through reinteractive's [OpsCare service](https://reinteractive.net/service/ops-care).
+it is a Ruby on Rails application created and built by [reinteractive](https://reinteractive.com/)
+and hosted through reinteractive's [OpsCare service](https://reinteractive.com/service/ops-care).
 It has been made open source to ensure transparency on the service and to encourage contribution
 to improve the security of the application.
 
@@ -113,7 +113,7 @@ Staging Environment
 TopSekr.it staging is deployed from the develop branch.
 
 The environment is run with continuous development and continuous integration
-on the [reinteractive OpsCare](https://reinteractive.net/service/ops-care)
+on the [reinteractive OpsCare](https://reinteractive.com/service/ops-care)
 service on top of AWS cloud.
 
 Pushing to develop will automatically deploy to the CI servers and once green

--- a/app/views/auth_tokens/new.html.erb
+++ b/app/views/auth_tokens/new.html.erb
@@ -111,7 +111,7 @@
     <div class="homepage-faq__question">
       <h3 data-slidetarget="setUp">Can you help us set this up?</h3>
       <div data-slide="setUp">
-        <p>Sure, <%= link_to "contact us", "https://reinteractive.net/enquiries/new?message=I%27d+like+to+get+some+more+information+to+setup+TopSekr.it..." %>  to get more information about our Ruby on Rails <%= link_to "OpsCare", "https://reinteractive.net/service/ops-care/" %> and <%= link_to "CodeCare", "https://reinteractive.net/service/code-care/" %> services.</p>
+        <p>Sure, <%= link_to "contact us", "https://reinteractive.com/enquiries/new?message=I%27d+like+to+get+some+more+information+to+setup+TopSekr.it..." %>  to get more information about our Ruby on Rails <%= link_to "OpsCare", "https://reinteractive.com/service/ops-care/" %> and <%= link_to "CodeCare", "https://reinteractive.com/service/code-care/" %> services.</p>
         <p>We are experts at keeping critical Rails applications online.</p>
       </div>
     </div>
@@ -124,12 +124,12 @@
       About TopSekr.it
     </h3>
     <div class="flex-column">
-      <p>TopSekr.it is available for anyone to use, it is a Ruby on Rails application created and built by <%= link_to "reinteractive", "https://reinteractive.net" %> and hosted through reinteractive's <%= link_to "OpsCare", "https://reinteractive.net/service/ops-care/" %> service. It has been made open source to ensure transparency on the service and to encourage contribution to improve the security of the application.</p>
+      <p>TopSekr.it is available for anyone to use, it is a Ruby on Rails application created and built by <%= link_to "reinteractive", "https://reinteractive.com" %> and hosted through reinteractive's <%= link_to "OpsCare", "https://reinteractive.com/service/ops-care/" %> service. It has been made open source to ensure transparency on the service and to encourage contribution to improve the security of the application.</p>
       <p>If you do not want to (or can not) use our hosted version, you are welcome to run your own version for your own company or organisation, we only</p>
     </div>
     <div class="flex-column">
       <p>stipulate that you may not run it as a service for third parties in competition to https://TopSekr.it/</p>
-      <p>If you would like assistance getting TopSekr.it (or any other Rails application) setup, hosted and maintained on AWS, please consider <%= link_to "contacting us", "https://reinteractive.net/enquiries/new?message=I%27d+like+to+get+some+more+information+to+setup+TopSekr.it..." %> to get more information about our Ruby on Rails <%= link_to "OpsCare", "https://reinteractive.net/service/ops-care/" %> and <%= link_to "CodeCare", "https://reinteractive.net/service/code-care/" %> services.</p>
+      <p>If you would like assistance getting TopSekr.it (or any other Rails application) setup, hosted and maintained on AWS, please consider <%= link_to "contacting us", "https://reinteractive.com/enquiries/new?message=I%27d+like+to+get+some+more+information+to+setup+TopSekr.it..." %> to get more information about our Ruby on Rails <%= link_to "OpsCare", "https://reinteractive.com/service/ops-care/" %> and <%= link_to "CodeCare", "https://reinteractive.com/service/code-care/" %> services.</p>
       <p>It is free to use and is governed by our <%= link_to "Terms & Conditions", "/terms_and_conditions" %>.</p>
     </div>
   </article>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,7 +1,7 @@
 <footer class="footer">
   <div class="container-fluid navbar navbar-static-bottom">
     <p class="attribution text-center">
-      Built, hosted and maintained by <%= link_to("reinteractive", "https://reinteractive.net/") %>.
+      Built, hosted and maintained by <%= link_to("reinteractive", "https://reinteractive.com/") %>.
     </p>
     <ul class="footer-links list-unstyled text-center">
       <li class="visible-xs-block visible-sm-inline-block visible-md-inline-block visible-lg-inline-block"><a href="">TopSekr.it</a></li>


### PR DESCRIPTION
I was using the service and noticed it was still using reinteractive's old domain.